### PR TITLE
using cudaStreamSynchronize() on ORT stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ if (MSVC)
 endif ()
 
 if(APPLE)
+    set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fobjc-arc")
 endif()
 

--- a/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
@@ -20,12 +20,23 @@ endif()
 
 project(mmdeploy_onnxruntime_ops)
 
-include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake)
+if (!APPLE)
+    include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake)
+endif()
 include(${CMAKE_SOURCE_DIR}/cmake/modules/FindONNXRUNTIME.cmake)
 
 # add plugin source
 
 file(GLOB_RECURSE ORT_OPS_SRCS *.cpp *.cu)
+if (NOT FOUND_CUDA)
+    set (EXCLUDE_CUDA_DIR "/cuda/")
+    foreach (TMP_PATH ${ORT_OPS_SRCS})
+        string (FIND ${TMP_PATH} ${EXCLUDE_CUDA_DIR} EXCLUDE_DIR_FOUND)
+        if (NOT ${EXCLUDE_DIR_FOUND} EQUAL -1)
+            list (REMOVE_ITEM ORT_OPS_SRCS ${TMP_PATH})
+        endif ()
+    endforeach(TMP_PATH)
+endif()
 add_library(${PROJECT_NAME}_obj OBJECT "${ORT_OPS_SRCS}")
 target_compile_definitions(${PROJECT_NAME}_obj PRIVATE -DMMDEPLOY_API_EXPORTS=1)
 target_compile_options(${PROJECT_NAME}_obj PRIVATE
@@ -41,7 +52,11 @@ target_include_directories(${PROJECT_NAME}_obj PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/csrc>)
-target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas cudart)
+if (FOUND_CUDA)
+    target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas cudart)
+else()
+    target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime)
+endif()
 
 mmdeploy_add_library(${PROJECT_NAME} SHARED EXCLUDE "")
 target_link_libraries(${PROJECT_NAME} PUBLIC ${PROJECT_NAME}_obj)

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
@@ -8,8 +8,22 @@ namespace mmdeploy {
 
 struct MMCVDeformConvKernel {
   MMCVDeformConvKernel(const OrtApi& api, const OrtKernelInfo *info);
+  ~MMCVDeformConvKernel();
 
   void Compute(OrtKernelContext *context);
+
+ private:
+  OrtOp* op_gemm_{};
+  void initGemm(Ort::CustomOpApi ort);
+  void deformConv(OrtKernelContext *context,
+    const float *src, const float *offset, const float *filter,
+    const int64_t batch, const int64_t src_c, const int64_t src_h,
+    const int64_t src_w, const int64_t dst_c, const int64_t dst_h,
+    const int64_t dst_w, const int64_t group, const int64_t offset_group,
+    const int64_t channels, const int64_t num_output, const int64_t kernel_h,
+    const int64_t kernel_w, const int64_t stride_h, const int64_t stride_w,
+    const int64_t pad_h, const int64_t pad_w, const int64_t dilation_h,
+    const int64_t dilation_w, float *columns, float *dst);
 
  protected:
   const OrtApi& api_;

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
@@ -20,6 +20,7 @@ struct MMCVDeformConvCUDAKernel {
   const OrtKernelInfo *info_;
   Ort::AllocatorWithDefaultOptions allocator_;
 
+  int cuda_dev_memory_pools_supported_;
   cublasHandle_t cublas_handle_ = nullptr;  // TODO:: release the cublas handle?
 
   int64_t stride_height_;
@@ -32,6 +33,9 @@ struct MMCVDeformConvCUDAKernel {
   int64_t group_;
   int64_t im2col_step_;
 
+private:
+  cudaError_t cuda_malloc(void **pointer, size_t size, cudaStream_t stream);
+  void cuda_free(void *pointer, cudaStream_t stream);
 };
 
 struct MMCVDeformConvCUDAOp


### PR DESCRIPTION
## Motivation

On Linux and Windows, we experienced inconsistent inference results between multiple runs of same image
it turns out we have to make sure custom ops and ORT session use same stream, and we have to use  cudaStreamSynchronize() also

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
