### PR TITLE
calling Gemm ORT operator in deformConv2D CPU customOp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ if (MSVC)
 endif ()
 
 if(APPLE)
+    set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fobjc-arc")
 endif()
 

--- a/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
@@ -20,12 +20,23 @@ endif()
 
 project(mmdeploy_onnxruntime_ops)
 
-include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake)
+if (!APPLE)
+    include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake)
+endif()
 include(${CMAKE_SOURCE_DIR}/cmake/modules/FindONNXRUNTIME.cmake)
 
 # add plugin source
 
 file(GLOB_RECURSE ORT_OPS_SRCS *.cpp *.cu)
+if (NOT FOUND_CUDA)
+    set (EXCLUDE_CUDA_DIR "/cuda/")
+    foreach (TMP_PATH ${ORT_OPS_SRCS})
+        string (FIND ${TMP_PATH} ${EXCLUDE_CUDA_DIR} EXCLUDE_DIR_FOUND)
+        if (NOT ${EXCLUDE_DIR_FOUND} EQUAL -1)
+            list (REMOVE_ITEM ORT_OPS_SRCS ${TMP_PATH})
+        endif ()
+    endforeach(TMP_PATH)
+endif()
 add_library(${PROJECT_NAME}_obj OBJECT "${ORT_OPS_SRCS}")
 target_compile_definitions(${PROJECT_NAME}_obj PRIVATE -DMMDEPLOY_API_EXPORTS=1)
 target_compile_options(${PROJECT_NAME}_obj PRIVATE
@@ -41,7 +52,11 @@ target_include_directories(${PROJECT_NAME}_obj PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/csrc>)
-target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas cudart)
+if (FOUND_CUDA)
+    target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas cudart)
+else()
+    target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime)
+endif()
 
 mmdeploy_add_library(${PROJECT_NAME} SHARED EXCLUDE "")
 target_link_libraries(${PROJECT_NAME} PUBLIC ${PROJECT_NAME}_obj)

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.cpp
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.cpp
@@ -264,6 +264,8 @@ MMCVDeformConvKernel::MMCVDeformConvKernel(const OrtApi& api,
 
   // create allocator
   allocator_ = Ort::AllocatorWithDefaultOptions();
+  // init Gemm Operator
+  initGemm(ort_);
 }
 
 MMCVDeformConvKernel::~MMCVDeformConvKernel() {

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.cpp
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.cpp
@@ -148,7 +148,7 @@ void deformable_im2col(const float *input, const float *offset,
   }
 }
 
-void deformable_conv_forward(
+void MMCVDeformConvKernel::deformConv(OrtKernelContext *context,
     const float *src, const float *offset, const float *filter,
     const int64_t batch, const int64_t src_c, const int64_t src_h,
     const int64_t src_w, const int64_t dst_c, const int64_t dst_h,
@@ -157,10 +157,23 @@ void deformable_conv_forward(
     const int64_t kernel_w, const int64_t stride_h, const int64_t stride_w,
     const int64_t pad_h, const int64_t pad_w, const int64_t dilation_h,
     const int64_t dilation_w, float *columns, float *dst) {
+
+  auto mem_info = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtArenaAllocator, OrtMemType::OrtMemTypeCPU);
+
   const int64_t ic_per_gp = channels / group;
   const int64_t oc_per_gp = num_output / group;
+
+  const int64_t M = oc_per_gp;
+  const int64_t K = ic_per_gp * kernel_h * kernel_w;
+  const int64_t N = dst_h * dst_w;
+
+  const int64_t raw_A_shape[2] = {M, K};
+  const int64_t raw_B_shape[2] = {K, N};
+  const int64_t raw_C_shape[2] = {M, N};
+
   for (int64_t b = 0; b < batch; ++b) {
     for (int64_t g = 0; g < group; ++g) {
+
       deformable_im2col(
           src + b * src_c * src_h * src_w + g * ic_per_gp * src_h * src_w,
           offset + b * offset_group * 2 * kernel_h * kernel_w * dst_h * dst_w,
@@ -172,17 +185,68 @@ void deformable_conv_forward(
 
       memset(dst_ptr, 0.0f, sizeof(float) * oc_per_gp * dst_h * dst_w);
 
+      float* pointerA = (float *)(filter + g * oc_per_gp * ic_per_gp * kernel_h * kernel_w);
+
+      auto A = Ort::Value::CreateTensor(mem_info, pointerA, M*K, raw_A_shape, 2);
+      auto B = Ort::Value::CreateTensor(mem_info, columns, K*N, raw_B_shape, 2);
+      auto C = Ort::Value::CreateTensor(mem_info, dst_ptr, M*N, raw_C_shape, 2);
+
+      auto Y = Ort::Value::CreateTensor(mem_info, dst_ptr, M*N, raw_C_shape, 2);
+
+      const OrtValue* inputs[3] = {(OrtValue*)A, (OrtValue*)B, (OrtValue*)C};
+      OrtValue* outputs[1] = {(OrtValue*)Y};
+
+      /*
       gemm_ref_fp32_deform(
           filter + g * oc_per_gp * ic_per_gp * kernel_h * kernel_w, columns,
           nullptr, dst_ptr, 0, 0, oc_per_gp, dst_h * dst_w,
           ic_per_gp * kernel_h * kernel_w, 1.0f, 1.0f, dst_ptr);
+       */
+      ort_.InvokeOp(context, op_gemm_, inputs, 3, outputs, 1);
     }
   }
 }
 
+void MMCVDeformConvKernel::initGemm(Ort::CustomOpApi ort) {
+  const char* type_constraint_names[1] = {"T"};
+  int type_constraint_values[1] = {1}; // float
+
+  int64_t transA = 0;
+  OrtOpAttr* attrTransA = ort.CreateOpAttr("transA", &transA, 1, OrtOpAttrType::ORT_OP_ATTR_INT);
+
+  int64_t transB = 0;
+  OrtOpAttr* attrTransB = ort.CreateOpAttr("transB", &transB, 1, OrtOpAttrType::ORT_OP_ATTR_INT);
+
+  float alpha = 1.0f;
+  OrtOpAttr* attrAlpha = ort.CreateOpAttr("alpha", &alpha, 1, OrtOpAttrType::ORT_OP_ATTR_FLOAT);
+
+  float beta = 1.0f;
+  OrtOpAttr* attrBeta = ort.CreateOpAttr("beta", &beta, 1, OrtOpAttrType::ORT_OP_ATTR_FLOAT);
+
+  if (!attrTransA || !attrTransB || !attrAlpha || !attrBeta) {
+    ORT_CXX_API_THROW("Failed to create attributes for gemm", ORT_FAIL);
+  }
+
+  OrtOpAttr* gemm_attrs[4] = {attrTransA, attrTransB, attrAlpha, attrBeta};
+  op_gemm_ = ort.CreateOp(info_, "Gemm", "", 11,
+                          (const char**)type_constraint_names,
+                          (const ONNXTensorElementDataType*)type_constraint_values,
+                          1, gemm_attrs, 4, 3, 1);
+
+  if (!op_gemm_) {
+    ORT_CXX_API_THROW("Failed to create gemm operator", ORT_FAIL);
+  }
+
+  ort.ReleaseOpAttr(attrTransA);
+  ort.ReleaseOpAttr(attrTransB);
+  ort.ReleaseOpAttr(attrAlpha);
+  ort.ReleaseOpAttr(attrBeta);
+}
+
 MMCVDeformConvKernel::MMCVDeformConvKernel(const OrtApi& api,
                                            const OrtKernelInfo *info)
-    : api_(api), ort_(api_), info_(info) {
+    : api_(api), ort_(api_) {
+  info_ = ort_.CopyKernelInfo(info);
   std::vector<int64_t> stride =
       ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "strides");
   stride_height_ = stride[0];
@@ -200,6 +264,11 @@ MMCVDeformConvKernel::MMCVDeformConvKernel(const OrtApi& api,
 
   // create allocator
   allocator_ = Ort::AllocatorWithDefaultOptions();
+}
+
+MMCVDeformConvKernel::~MMCVDeformConvKernel() {
+  ort_.ReleaseOp(op_gemm_);
+  ort_.ReleaseKernelInfo((OrtKernelInfo *)info_);
 }
 
 void MMCVDeformConvKernel::Compute(OrtKernelContext *context) {
@@ -256,12 +325,15 @@ void MMCVDeformConvKernel::Compute(OrtKernelContext *context) {
   int64_t column_len = (in_channels / group) * kernel_height * kernel_width *
                        out_height * out_width;
   float *columns = (float *)allocator_.Alloc(sizeof(float) * column_len);
-  deformable_conv_forward(
+
+  deformConv(context,
       input_data, offset_data, filter_data, batch_size, in_channels, in_height,
       in_width, out_channels, out_height, out_width, group, deformable_group,
       in_channels, out_channels, kernel_height, kernel_width, stride_height,
       stride_width, padding_height, padding_width, dilation_height,
       dilation_width, columns, out_ptr);
+
+  allocator_.Free(columns);
 }
 
 static char __openvino[] = "org.openvinotoolkit";

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
@@ -8,8 +8,22 @@ namespace mmdeploy {
 
 struct MMCVDeformConvKernel {
   MMCVDeformConvKernel(const OrtApi& api, const OrtKernelInfo *info);
+  ~MMCVDeformConvKernel();
 
   void Compute(OrtKernelContext *context);
+
+ private:
+  OrtOp* op_gemm_{};
+  void initGemm(Ort::CustomOpApi ort);
+  void deformConv(OrtKernelContext *context,
+    const float *src, const float *offset, const float *filter,
+    const int64_t batch, const int64_t src_c, const int64_t src_h,
+    const int64_t src_w, const int64_t dst_c, const int64_t dst_h,
+    const int64_t dst_w, const int64_t group, const int64_t offset_group,
+    const int64_t channels, const int64_t num_output, const int64_t kernel_h,
+    const int64_t kernel_w, const int64_t stride_h, const int64_t stride_w,
+    const int64_t pad_h, const int64_t pad_w, const int64_t dilation_h,
+    const int64_t dilation_w, float *columns, float *dst);
 
  protected:
   const OrtApi& api_;

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
@@ -20,6 +20,7 @@ struct MMCVDeformConvCUDAKernel {
   const OrtKernelInfo *info_;
   Ort::AllocatorWithDefaultOptions allocator_;
 
+  int cuda_dev_memory_pools_supported_;
   cublasHandle_t cublas_handle_ = nullptr;  // TODO:: release the cublas handle?
 
   int64_t stride_height_;
@@ -32,6 +33,9 @@ struct MMCVDeformConvCUDAKernel {
   int64_t group_;
   int64_t im2col_step_;
 
+private:
+  cudaError_t cuda_malloc(void **pointer, size_t size, cudaStream_t stream);
+  void cuda_free(void *pointer, cudaStream_t stream);
 };
 
 struct MMCVDeformConvCUDAOp


### PR DESCRIPTION
## Motivation
to improve the speed of deformConv2D CPU customOp
calling Gemm ORT operator

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
