### PR TITLE
fix: bump protobuf to 3.20.3

### DIFF
--- a/.github/workflows/backend-pplnn.yml
+++ b/.github/workflows/backend-pplnn.yml
@@ -70,7 +70,7 @@ jobs:
         id: badge_status
         run: |
           python -m pip install torch==1.8.2 torchvision==0.9.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cpu
-          python -m pip install mmcv-lite protobuf==3.20.2
+          python -m pip install mmcv-lite protobuf==3.20.3
           python tools/scripts/build_ubuntu_x64_pplnn.py 8
           python -c 'import mmdeploy.apis.pplnn as pplnn_api; assert pplnn_api.is_available()'
       - name: create badge

--- a/mmdeploy/version.py
+++ b/mmdeploy/version.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from typing import Tuple
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 short_version = __version__
 
 

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,6 +6,6 @@ multiprocess
 numpy
 onnx>=1.13.0
 prettytable
-protobuf<=3.20.2
+protobuf<=3.20.3
 six
 terminaltables

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,7 +4,7 @@ matplotlib
 mmengine
 multiprocess
 numpy
-onnx>=1.13.0
+onnx>=1.13.0,<=1.16.2
 prettytable
 protobuf<=3.20.3
 six


### PR DESCRIPTION
## Motivation

So that new TF versions are compatible with mmdeploy.

Tests that are failing in the original repo:
![image](https://github.com/user-attachments/assets/47a0ee8b-b758-4ec1-ac22-29cecfb528d4)
